### PR TITLE
Support legacy skills discovery routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Let your users do this: `npx skills add https://your-website-here.com/`
 
-Bundle [Agent Skills](https://agentskills.io/) into your Astro site, for others to consume by URL. This integration implements the [Agent Skills Discovery RFC](https://github.com/elithrar/agent-skills-discovery-rfc), allowing AI agents to discover and use skills published on your website. 
+Bundle [Agent Skills](https://agentskills.io/) into your Astro site, for others to consume by URL. This integration implements the [Agent Skills Discovery RFC](https://github.com/agentskills/agentskills/pull/254), allowing AI agents to discover and use skills published on your website. 
 
-- Automatically generates your `/.well-known/skills/index.json` index file.
+- Automatically generates your `/.well-known/agent-skills/index.json` index file.
 - Validates your skills, frontmatter, etc. for compliance.
 - Designed for Astro [Content Collections](https://docs.astro.build/en/guides/content-collections/).
 
@@ -71,5 +71,5 @@ export const collections = {
 ## Learn More
 
 - [Agent Skills Specification](https://agentskills.io/specification)
-- [Agent Skills Discovery RFC](https://github.com/elithrar/agent-skills-discovery-rfc)
+- [Agent Skills Discovery RFC](https://github.com/agentskills/agentskills/pull/254)
 - [Astro Content Collections](https://docs.astro.build/en/guides/content-collections/)

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,20 @@ export default function skillsIntegration(): AstroIntegration {
 					entrypoint: 'astro-skills/routes/skill-archive',
 				});
 
+				// Keep the legacy v0.1 discovery paths working while clients migrate to v0.2.
+				injectRoute({
+					pattern: '/.well-known/skills/index.json',
+					entrypoint: 'astro-skills/routes/index-json',
+				});
+				injectRoute({
+					pattern: '/.well-known/skills/[skill]/SKILL.md',
+					entrypoint: 'astro-skills/routes/skill-md',
+				});
+				injectRoute({
+					pattern: '/.well-known/skills/[skill].tar.gz',
+					entrypoint: 'astro-skills/routes/skill-archive',
+				});
+
 				logger.info('Agent Skills Discovery routes configured');
 			},
 		},

--- a/src/routes/index-json.ts
+++ b/src/routes/index-json.ts
@@ -7,7 +7,7 @@ import { SCHEMA_URI } from '../types.js';
  *
  * Returns a JSON index of all available skills per the Agent Skills Discovery RFC v0.2.0.
  *
- * @see https://github.com/cloudflare/agent-skills-discovery-rfc
+ * @see https://github.com/agentskills/agentskills/pull/254
  */
 export const GET: APIRoute = async () => {
 	// Dynamic import of virtual module - resolved at runtime by Astro

--- a/src/routes/skill-archive.ts
+++ b/src/routes/skill-archive.ts
@@ -25,7 +25,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
  * Serves the pre-generated tar.gz archive for an archive type skill
  * per the Agent Skills Discovery RFC v0.2.0.
  *
- * @see https://github.com/cloudflare/agent-skills-discovery-rfc
+ * @see https://github.com/agentskills/agentskills/pull/254
  */
 export const GET: APIRoute = async ({ params }) => {
 	const { skill } = params;

--- a/src/routes/skill-md.ts
+++ b/src/routes/skill-md.ts
@@ -25,7 +25,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
  *
  * Serves the SKILL.md file for a skill per the Agent Skills Discovery RFC v0.2.0.
  *
- * @see https://github.com/cloudflare/agent-skills-discovery-rfc
+ * @see https://github.com/agentskills/agentskills/pull/254
  */
 export const GET: APIRoute = async ({ params }) => {
 	const { skill } = params;


### PR DESCRIPTION
## Summary

Adds compatibility aliases for the legacy `/.well-known/skills/*` discovery routes while keeping the v0.2 `/.well-known/agent-skills/*` routes as the documented path.

The `.well-known` URI spec is landing in agentskills/agentskills#254, and this keeps existing v0.1 consumers working during migration.

## Testing

- `pnpm run build`
